### PR TITLE
ptp: Add parameter for utc/tai offset in ptp mode.

### DIFF
--- a/launch/common.launch
+++ b/launch/common.launch
@@ -5,6 +5,7 @@
   <arg name="rviz_config" doc="optional rviz config file"/>
   <arg name="tf_prefix" doc="namespace for tf transforms"/>
   <arg name="timestamp_mode" doc="method used to timestamp measurements"/>
+  <arg name="ptp_utc_tai_offset_secs" doc="UTC/TAI offset to apply when using TIME_FROM_PTP_1588"/>
 
   <group ns="$(arg ouster_ns)">
     <node pkg="nodelet" type="nodelet" name="os_cloud_node"
@@ -13,6 +14,7 @@
       args="load nodelets_os/OusterCloud os_nodelet_mgr">
       <param name="~/tf_prefix" type="str" value="$(arg tf_prefix)"/>
       <param name="~/timestamp_mode" type="str" value="$(arg timestamp_mode)"/>
+      <param name="~/ptp_utc_tai_offset_secs" type="int" value="$(arg ptp_utc_tai_offset_secs)"/>
     </node>
   </group>
 

--- a/launch/record.launch
+++ b/launch/record.launch
@@ -25,6 +25,7 @@
     TIME_FROM_PTP_1588,
     TIME_FROM_ROS_TIME
     }"/>
+  <arg name="ptp_utc_tai_offset_secs" default="-37" doc="UTC/TAI offset to apply when using TIME_FROM_PTP_1588"/>
   <arg name="metadata" doc="path to write metadata file when receiving sensor data"/>
   <arg name="bag_file" default="" doc="file name to use for the recorded bag file"/>
   <arg name="viz" default="true" doc="whether to run a rviz"/>
@@ -50,6 +51,7 @@
       <param name="~/udp_profile_lidar" type="str" value="$(arg udp_profile_lidar)"/>
       <param name="~/lidar_mode" type="str" value="$(arg lidar_mode)"/>
       <param name="~/timestamp_mode" type="str" value="$(arg timestamp_mode)"/>
+      <param name="~/ptp_utc_tai_offset_secs" type="int" value="$(arg ptp_utc_tai_offset_secs)"/>
       <param name="~/metadata" type="str" value="$(arg metadata)"/>
     </node>
   </group>
@@ -60,6 +62,7 @@
     <arg name="rviz_config" value="$(arg rviz_config)"/>
     <arg name="tf_prefix" value="$(arg tf_prefix)"/>
     <arg name="timestamp_mode" value="$(arg timestamp_mode)"/>
+    <arg name="ptp_utc_tai_offset_secs" value="$(arg ptp_utc_tai_offset_secs)"/>
   </include>
 
   <arg name="_use_bag_file_name" value="$(eval not (bag_file == ''))"/>

--- a/launch/sensor.launch
+++ b/launch/sensor.launch
@@ -25,6 +25,7 @@
     TIME_FROM_PTP_1588,
     TIME_FROM_ROS_TIME
     }"/>
+  <arg name="ptp_utc_tai_offset_secs" default="-37" doc="UTC/TAI offset to apply when using TIME_FROM_PTP_1588"/>
   <arg name="metadata" default=" " doc="path to write metadata file when receiving sensor data"/>
   <arg name="viz" default="true" doc="whether to run a rviz"/>
   <arg name="rviz_config" default="$(find ouster_ros)/config/viz.rviz" doc="optional rviz config file"/>
@@ -49,6 +50,7 @@
       <param name="~/udp_profile_lidar" type="str" value="$(arg udp_profile_lidar)"/>
       <param name="~/lidar_mode" type="str" value="$(arg lidar_mode)"/>
       <param name="~/timestamp_mode" type="str" value="$(arg timestamp_mode)"/>
+      <param name="~/ptp_utc_tai_offset_secs" type="int" value="$(arg ptp_utc_tai_offset_secs)"/>
       <param name="~/metadata" type="str" value="$(arg metadata)"/>
     </node>
   </group>
@@ -59,6 +61,7 @@
     <arg name="rviz_config" value="$(arg rviz_config)"/>
     <arg name="tf_prefix" value="$(arg tf_prefix)"/>
     <arg name="timestamp_mode" value="$(arg timestamp_mode)"/>
+    <arg name="ptp_utc_tai_offset_secs" value="$(arg ptp_utc_tai_offset_secs)"/>
   </include>
 
 </launch>


### PR DESCRIPTION
## Related Issues & PRs

## Summary of Changes

Add `ptp_utc_tai_offset_secs` parameter to account for UTC/TAI offset.

International Atomic Time (TAI) is currently ahead of UTC by 37 seconds, so that is the default setting for the new parameter.

## Validation

- Tested with OS0 32 beam lidar on robot with hardware ptp support with ptp4l and phc2sys running as services.

- Used the following command to launch the driver:

```
roslaunch ouster_ros sensor.launch sensor_hostname:=<sensor-ip> viz:=false timestamp_mode:=TIME_FROM_PTP_1588 lidar_mode:=1024x10 ptp_utc_tai_offset_secs:=-37
```

- Previously, timestamps for the point clouds published on `ouster/points` were in the future by approximately -36.9 seconds compared to UTC system time. After the change, the timestamps are now milliseconds in the past as expected. Similarly for the imu messages published on `ouster/imu`, the timestamp difference is now less than a millisecond compared with system time.